### PR TITLE
using Deezer SDK instead of axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ so name your files before uploading and avoid special and unnecessary characters
 
 i.e. valid file name could be **_XXXTentacion Sad_**
 
-Note: App is using demo proxy ([cors-anywhere.herokuapp.com](https://cors-anywhere.herokuapp.com/)) to reach Deezer API.
-The number of requests is limited to 200 per 60 minutes.
-Please self-host [CORS Anywhere](https://github.com/Rob--W/cors-anywhere/) if you need more quota or embed this app within your server application.
-
 ## Project setup
 ```
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mp3-metadata-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mp3-metadata-app",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/public/index.html
+++ b/public/index.html
@@ -29,5 +29,7 @@
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+    <div id="dz-root"></div>
+    <script src="https://e-cdns-files.dzcdn.net/js/min/dz.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Used axios for getting data from Deezer API in previous version. Needed proxy URL to make calls directly from SPA, so it was used https://cors-anywhere.herokuapp.com/ for demo proxy. In meantime, changed from axios and using proxy URL to Deezer's SDK for Javascript, so no need for proxy URL and no call limits in that way