### PR TITLE
batch processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mp3-metadata-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "mp3-metadata-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
+  "author": {
+    "name": "Benjamin Fajic",
+    "url": "https://github.com/fajicbenjamin"
+  },
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
Now processing songs in batches of 10 songs per 5 seconds, to avoid hitting Deezer API rate limits, and to give browser enough time to download all songs